### PR TITLE
fix: correct parseInt for port

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import app from './app';
 console.log('⚾ Curveball v%s', require('@curveball/core/package.json').version);
 
 // The HTTP port can be overridden via the 'PORT' environment variable.
-const port = process.env.PORT ? parseInt(process.env.PORT, 12) : 8500;
+const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 8500;
 app.listen(8500);
 
 console.log('Listening on port %i', port);


### PR DESCRIPTION
Fixes port parseInt.

Before:
![2020-03-21-121648_542x153_scrot](https://user-images.githubusercontent.com/12520493/77233560-38329580-6ba0-11ea-85af-b723e8990f09.png)

After:
![2020-03-21-121705_554x155_scrot](https://user-images.githubusercontent.com/12520493/77233562-3cf74980-6ba0-11ea-9762-27723744b71e.png)
